### PR TITLE
fix: Total Progress Temp Logic

### DIFF
--- a/app/models/sprint.rb
+++ b/app/models/sprint.rb
@@ -40,7 +40,9 @@ class Sprint < ApplicationRecord
 
   def count_weekly_progress_average(user)
     week_averages = self.weeks.where('start_date < ?', Date.today).map do |week|
-      week.calc_user_average_timeline_progress(user)
+      average = week.calc_user_average_timeline_progress(user)
+      # FIXME The logic below is temporary and can be removed after Sprint 2
+      average > 10 ? 0 : average
     end
 
     # Calculate the average of all week averages if there are any weeks

--- a/app/views/pages/learner_profile.html.erb
+++ b/app/views/pages/learner_profile.html.erb
@@ -157,6 +157,10 @@
               <% @current_sprint_weeks.each do |week| %>
                 <td>
                   <% relative_progress = week.calc_relative_average_timeline_progress(@learner) %>
+                  <%# FIXME The logic below is temporary to hide initial
+                      progress without previous week progress.
+                      Logic can be removed after Sprint 3
+                  %>
                   <% if relative_progress > 10 %>
                     N/A
                   <% else %>


### PR DESCRIPTION
Added temp logic to discard average progress that is over 10% to discard initial setups. This logic can be removed after Sprint 2