### PR TITLE
fix:[Attendance] Duplicated Attendance Rake Tasks

### DIFF
--- a/lib/tasks/destroy_duplicated_attendances.rake
+++ b/lib/tasks/destroy_duplicated_attendances.rake
@@ -4,9 +4,9 @@ namespace :attendances do
     puts "Starting duplicate removal process..."
 
     duplicates = Attendance
-                   .select('user_id, attendance_date, COUNT(*) as count')
+                   .select('user_id, attendance_date')
                    .group('user_id, attendance_date')
-                   .having('count > 1')
+                   .having('COUNT(*) > 1')
 
     duplicates.each do |duplicate|
       user_id = duplicate.user_id

--- a/lib/tasks/merge_duplicated_attendances.rake
+++ b/lib/tasks/merge_duplicated_attendances.rake
@@ -4,9 +4,9 @@ namespace :attendances do
     puts "Starting deduplication process..."
 
     duplicates = Attendance
-                   .select('user_id, attendance_date, COUNT(*) as count')
+                   .select('user_id, attendance_date')
                    .group('user_id, attendance_date')
-                   .having('count > 1')
+                   .having('COUNT(*) > 1')
 
     duplicates.each do |duplicate|
       user_id = duplicate.user_id
@@ -27,6 +27,7 @@ namespace :attendances do
 
       records.each do |record|
         record.update!(merged_attributes)
+        puts "updated attendance: #{record.id}"
       end
     end
 


### PR DESCRIPTION
Created the following rake tasks:

1. merge_duplicated_attendances

Find duplicate attendances and merge filled out columns
Run: `rake attendances:merge_duplicated_attendances`

3. destroy_duplicated_attendances

Find duplicate attendences and duplicates, keeping the first created
Run: `rake attendances:destroy_duplicated_attendances`