### PR TITLE
fix:[Timelines] blocks and percentages display

### DIFF
--- a/app/views/timelines/index.html.erb
+++ b/app/views/timelines/index.html.erb
@@ -56,7 +56,9 @@
               <div style="margin-right: 130px;">
                 <h5 class="mb-0" style="margin-top: 12px">Blocks per day: <%= (@total_blocks_per_day * 1.2).round(1)  %></h5>
               </div>
-          <% else %>
+          <% end %>
+
+          <% unless @average_weekly_percentage.nan? %>
             <div >
               <h5 class="mb-0" style="margin-top: 12px">Expected weekly progress: <%= @average_weekly_percentage %>% / <%= (@total_hours_per_week).round() %>h</h5>
             </div>


### PR DESCRIPTION
Added logic to display both blocks as well as percentages in case it is appropriate.

Personalized Timelines will not affect the display